### PR TITLE
Fix compile-time errors for "native" pio run

### DIFF
--- a/src/Bytes.h
+++ b/src/Bytes.h
@@ -8,9 +8,33 @@
 #include <stddef.h>
 #include <string.h>
 #include <stdlib.h>
+
 #include <vector>
 #include <string>
 #include <memory>
+
+/**
+ * The `strnstr()` function locates the first occurrence of the 
+ * null-terminated string `little` in the string `big`, where not more 
+ * than `len` characters are searched.
+ * Characters that appear after a `\0' character are not searched.
+ *
+ * Implementation of FreeBSD-specific function.
+ */
+inline char* strnstr(const char* big, const char* little, size_t len) {
+    // isn't safe if little isn't null terminated
+    size_t little_len = strnlen(little, len);
+
+    for (size_t pos = 0; pos < len-little_len; pos++) {
+        static const char* curr = (big + pos);
+
+        if (strncmp(curr, little, little_len) == 0) {
+            return const_cast<char*>(curr);
+        }
+    }
+
+    return NULL;
+}
 
 namespace RNS {
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -5,6 +5,7 @@
 #endif
 
 #include <string>
+#include <cstdarg> // va_start, va_end
 
 #define LOG(msg, level) (RNS::log(msg, level))
 #define LOGF(level, msg, ...) (RNS::logf(level, msg, __VA_ARGS__))

--- a/src/Utilities/Print.h
+++ b/src/Utilities/Print.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string>
+#include <cstring> // strlen
 
 #define DEC 10
 #define HEX 16


### PR DESCRIPTION
Solves #4 compile-time errors. Implements strnstr() for portability, probably one could use different standard function (like strstr()).

It is important that `pio run -e native` tries to compile to executable, but can't find main() entry point function. This merge won't solve whole #4, which requires further discussion on approach for this project.