### PR TITLE
fix: enable LoRa CRC on SX127x for RNode interop

### DIFF
--- a/examples/common/lora_interface/LoRaInterface.cpp
+++ b/examples/common/lora_interface/LoRaInterface.cpp
@@ -109,6 +109,13 @@ bool LoRaInterface::start() {
 	// begin(freq MHz, bw kHz, sf, cr, syncWord, power dBm, preamble symbols, LNA gain 0=AGC)
 	int state = chip->begin(frequency, bandwidth, spreading, coding,
 	                        RADIOLIB_SX127X_SYNC_WORD, power, 20, 0);
+	// SX127x hardware default leaves RxPayloadCrcOn=0 and RadioLib's
+	// SX127x::begin() does not touch it. Upstream RNode firmware enables
+	// CRC unconditionally (sx127x::enableCrc, RNode_Firmware.ino:531), so
+	// real RNodes silently drop frames without a CRC. Enable it here to
+	// interoperate. SX126x branches below inherit CRC-on from
+	// SX126x::begin() (setCRC(2)), so no explicit call is needed there.
+	if (state == RADIOLIB_ERR_NONE) state = chip->setCRC(true);
 
 #elif defined(BOARD_RAK4631)
 	// nRF52: SPI pins must be configured before SPI.begin()


### PR DESCRIPTION
## Summary

Enable LoRa CRC in the SX127x branch of the example `LoRaInterface`.
Without this, T-Beam and LoRa32 V2.1 boards running microReticulum
cannot interoperate with real RNode hardware: outbound frames are
silently dropped at the RNode, and inbound frames lack the CRC check
that Arduino-LoRa-era receivers used to rely on.

## Why

After reset, `REG_MODEM_CONFIG_2` bit 2 (`RxPayloadCrcOn`) on SX127x
is `0`, and `SX127x::begin()` does not touch it. `SX127x::config()`
only disables frequency hopping. So CRC stays off.

Upstream RNode firmware explicitly enables CRC on SX127x:

- `RNode_Firmware/RNode_Firmware.ino:531`: `LoRa->enableCrc();`
- `RNode_Firmware/sx127x.cpp:160`: `enableCrc();` called from the
  equivalent of `begin()`.

So any peer speaking the RNode wire format expects a CRC on every
LoRa frame and drops those that arrive without one. microReticulum's
example interface needs to match that expectation.

## What changed

One file, inside `LoRaInterface::start()` in the
`BOARD_TBEAM / BOARD_LORA32_V21` branch, immediately after
`chip->begin(...)`:

```cpp
if (state == RADIOLIB_ERR_NONE) state = chip->setCRC(true);
```

Gated on the prior `begin()` having succeeded; its own return value
is folded into `state` so the existing `RADIOLIB_ERR_NONE` check
below catches a CRC-enable failure too.

## Not changed

SX126x branches (RAK4631, Heltec V3, Heltec V4) are untouched.
RadioLib's `SX126x::begin()` already calls `setCRC(2)` internally
(`SX126x.cpp:61,114`), so those boards inherit CRC-on by default.
Adding an explicit call there would be defensive but noisy; happy to
add it if you prefer.

## Test plan

- [ ] T-Beam or LoRa32 V2.1 running this branch can send LoRa
      announces that a real RNode (or Python RNS with
      `RNodeInterface`) receives and delivers into transport.
- [ ] Announces originating from a real RNode arrive intact at the
      microReticulum node.
- [ ] SX126x targets (Heltec V3, RAK4631, etc.) continue to build
      and interoperate unchanged.


---

*Note: this PR was prepared with the help of generative AI as part of work on the [RTReticulum](https://github.com/0xSeren/RTReticulum) project. While the problem was manually identified, the patch, commit message, and this description were drafted by an AI assistant and reviewed by a human before submission.*
