### PR TITLE
improves diagnosis/log severity when the existing path is still present.

### DIFF
--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -2225,9 +2225,13 @@ DestinationEntry empty_destination_entry;
 							else {
 								ttl = DESTINATION_TIMEOUT;
 							}
+							const bool path_already_known = _new_path_table.exists(packet.destination_hash().collection());
 							if (_new_path_table.put(packet.destination_hash().collection(), destination_table_entry, ttl)) {
 								TRACEF("Added destination %s to path table!", packet.destination_hash().toHex().c_str());
 								++_destinations_added;
+							}
+							else if (path_already_known || _new_path_table.exists(packet.destination_hash().collection())) {
+								NOTICEF("Path table already has destination %s; keeping existing path entry", packet.destination_hash().toHex().c_str());
 							}
 							else {
 								ERRORF("Failed to add destination %s to path table!", packet.destination_hash().toHex().c_str());


### PR DESCRIPTION
Distinguish duplicate/known path-table announce from actual insertion failure.

When _new_path_table.put() returns false while the destination already exists in the path table, log this as an already-known path instead of an error. This avoids alarming error output during repeated announces while preserving the existing error log for true insertion failures.

I've create a test where two LilyGO T-Beam SUPREMES are linking to each other and after the LINK is created, they continue to announce and the recipient finds the entry already exists.  Rather than state error to the unsophisticated user that I am, I felt the more explicit message of:

     Path table already has destination %s; keeping existing path entry
     
would be an improvement.
<img width="957" height="564" alt="20260519_124903_Tue" src="https://github.com/user-attachments/assets/d9b19453-23f8-4a40-88e8-63389cd92943" />

