### PR TITLE
fix: return Ed25519 verify result from Identity::validate

### DIFF
--- a/src/microReticulum/Identity.cpp
+++ b/src/microReticulum/Identity.cpp
@@ -663,8 +663,7 @@ bool Identity::validate(const Bytes& signature, const Bytes& message) const {
 	if (_object->_pub) {
 		try {
 			TRACEF("Identity::validate: Attempting to verify signature: %s and message: %s", signature.toHex().c_str(), message.toHex().c_str());
-			_object->_sig_pub->verify(signature, message);
-			return true;
+			return _object->_sig_pub->verify(signature, message);
 		}
 		catch (const std::exception& e) {
 			return false;

--- a/test/test_crypto/test_crypto.cpp
+++ b/test/test_crypto/test_crypto.cpp
@@ -1,11 +1,13 @@
 #include <unity.h>
 
 #include "microReticulum/Bytes.h"
+#include "microReticulum/Identity.h"
 #include "microReticulum/Utilities/Crc.h"
 #include "microReticulum/Cryptography/HMAC.h"
 #include "microReticulum/Cryptography/PKCS7.h"
 
 #include <string.h>
+#include <vector>
 #include <unistd.h>
 #include <time.h>
 #include <stdint.h>
@@ -192,6 +194,24 @@ void testByteCrc32() {
 }
 
 
+void testIdentityValidate() {
+	RNS::Identity identity(true);
+	RNS::Bytes message("the quick brown fox jumps over the lazy dog");
+
+	RNS::Bytes signature = identity.sign(message);
+	TEST_ASSERT_TRUE(identity.validate(signature, message));
+
+	// A signature with a flipped byte must not validate.
+	std::vector<uint8_t> tampered(signature.data(), signature.data() + signature.size());
+	tampered[0] ^= 0xFF;
+	RNS::Bytes bad_signature(tampered.data(), tampered.size());
+	TEST_ASSERT_FALSE(identity.validate(bad_signature, message));
+
+	// A valid signature against a different message must not validate.
+	RNS::Bytes other_message("the quick brown fox jumps over the lazy cat");
+	TEST_ASSERT_FALSE(identity.validate(signature, other_message));
+}
+
 void setUp(void) {
     // set stuff up here before each test
 }
@@ -208,6 +228,7 @@ int runUnityTests(void) {
 	RUN_TEST(testCrc32);
 	RUN_TEST(testIncrementalCrc32);
 	RUN_TEST(testByteCrc32);
+	RUN_TEST(testIdentityValidate);
     return UNITY_END();
 }
 


### PR DESCRIPTION
## Summary

`Identity::validate` called `_sig_pub->verify(signature, message)` but discarded its
`bool` return and unconditionally returned `true` on the no-exception path. Since
`Ed25519PublicKey::verify` returns `false` on a signature mismatch rather than throwing,
any non-matching signature was accepted as valid. This returns the verify result directly.

Fixes #51.

## Test

Added `testIdentityValidate` to `test_crypto`: signs a message and checks that the valid
signature passes, while a signature with a flipped byte and a valid signature against a
different message both fail. The new test fails on master and passes with this change
(`pio test -e native17 -f test_crypto`).
