### PR TITLE
Fix crash because missing identity

### DIFF
--- a/src/Identity.cpp
+++ b/src/Identity.cpp
@@ -243,6 +243,7 @@ Recall identity for a destination hash.
 */
 /*static*/ Identity Identity::recall(const Bytes& destination_hash) {
 	TRACE("Identity::recall...");
+
 	auto iter = _known_destinations.find(destination_hash);
 	if (iter != _known_destinations.end()) {
 		TRACEF("Identity::recall: Found identity entry for destination %s", destination_hash.toHex().c_str());
@@ -252,19 +253,37 @@ Recall identity for a destination hash.
 		identity.app_data(identity_data._app_data);
 		return identity;
 	}
-	else {
-		TRACEF("Identity::recall: Unable to find identity entry for destination %s, performing destination lookup...", destination_hash.toHex().c_str());
-		Destination registered_destination(Transport::find_destination_from_hash(destination_hash));
-		if (registered_destination) {
-			TRACEF("Identity::recall: Found destination %s", destination_hash.toHex().c_str());
-			Identity identity(false);
-			identity.load_public_key(registered_destination.identity().get_public_key());
-			identity.app_data({Bytes::NONE});
-			return identity;
-		}
-		TRACEF("Identity::recall: Unable to find destination %s", destination_hash.toHex().c_str());
-		return {Type::NONE};
+	
+	Packet announce_packet = Transport::find_announce_packet_from_hash(destination_hash);
+	if (announce_packet) {
+		TRACEF("Identity::recall: Extracted identity entry from announce packet for destination %s", destination_hash.toHex().c_str());
+		Bytes public_key = announce_packet.data().left(KEYSIZE/8);
+		Bytes app_data = announce_packet.data().mid(KEYSIZE/8 + NAME_HASH_LENGTH/8 + RANDOM_HASH_LENGTH/8 + SIGLENGTH/8);	
+
+		Identity identity(false);
+		identity.load_public_key(public_key);
+		identity.app_data(app_data);
+
+		remember(announce_packet.get_hash(), destination_hash, public_key, app_data);
+		return identity;
 	}
+
+	TRACEF("Identity::recall: Unable to find identity entry for destination %s, performing destination lookup...", destination_hash.toHex().c_str());
+	Destination registered_destination(Transport::find_destination_from_hash(destination_hash));
+	if (registered_destination) {
+		TRACEF("Identity::recall: Found destination %s", destination_hash.toHex().c_str());
+		if (!registered_destination.identity()) {
+			TRACEF("Identity::recall: Destination %s has no associated identity", destination_hash.toHex().c_str());
+			return {Type::NONE};
+		}
+		Identity identity(false);
+		identity.load_public_key(registered_destination.identity().get_public_key());
+		identity.app_data({Bytes::NONE});
+		return identity;
+	}
+
+	TRACEF("Identity::recall: Unable to find destination %s", destination_hash.toHex().c_str());
+	return {Type::NONE};
 }
 
 /*

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -2464,27 +2464,32 @@ DestinationEntry empty_destination_entry;
 								}
 								Bytes peer_pub_bytes = packet.data().mid(Type::Identity::SIGLENGTH/8, Type::Link::ECPUBSIZE/2);
 								Identity peer_identity = Identity::recall(link_entry._destination_hash);
-								Bytes peer_sig_pub_bytes = peer_identity.get_public_key().mid(Type::Link::ECPUBSIZE/2, Type::Link::ECPUBSIZE/2);
+								if (peer_identity) {
+									Bytes peer_sig_pub_bytes = peer_identity.get_public_key().mid(Type::Link::ECPUBSIZE/2, Type::Link::ECPUBSIZE/2);
 
-								Bytes signed_data = packet.destination_hash() + peer_pub_bytes + peer_sig_pub_bytes + signalling_bytes;
-								Bytes signature = packet.data().left(Type::Identity::SIGLENGTH/8);
+									Bytes signed_data = packet.destination_hash() + peer_pub_bytes + peer_sig_pub_bytes + signalling_bytes;
+									Bytes signature = packet.data().left(Type::Identity::SIGLENGTH/8);
 
-								if (peer_identity.validate(signature, signed_data)) {
-									TRACEF("Link request proof validated for transport via %s", link_entry._receiving_interface.toString().c_str());
-									//p new_raw = packet.raw[0:1]
-									// CBA RESERVE
-									//Bytes new_raw = packet.raw().left(1);
-									Bytes new_raw(512);
-									new_raw << packet.raw().left(1);
-									//p new_raw += struct.pack("!B", packet.hops)
-									new_raw << packet.hops();
-									//p new_raw += packet.raw[2:]
-									new_raw << packet.raw().mid(2);
-									link_entry._validated = true;
-									transmit(link_entry._receiving_interface, new_raw);
+									if (peer_identity.validate(signature, signed_data)) {
+										TRACEF("Link request proof validated for transport via %s", link_entry._receiving_interface.toString().c_str());
+										//p new_raw = packet.raw[0:1]
+										// CBA RESERVE
+										//Bytes new_raw = packet.raw().left(1);
+										Bytes new_raw(512);
+										new_raw << packet.raw().left(1);
+										//p new_raw += struct.pack("!B", packet.hops)
+										new_raw << packet.hops();
+										//p new_raw += packet.raw[2:]
+										new_raw << packet.raw().mid(2);
+										link_entry._validated = true;
+										transmit(link_entry._receiving_interface, new_raw);
+									}
+									else {
+										DEBUGF("Invalid link request proof in transport for link %s, dropping proof.", packet.destination_hash().toHex().c_str());
+									}
 								}
 								else {
-									DEBUGF("Invalid link request proof in transport for link %s, dropping proof.", packet.destination_hash().toHex().c_str());
+									DEBUGF("Could not recall identity for link request proof destination %s, dropping proof.", link_entry._destination_hash.toHex().c_str());
 								}
 							}
 						}

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -4772,6 +4772,16 @@ TRACEF("Transport::write_path_table: buffer size %lu bytes", Persistence::_buffe
 	return {Type::NONE};
 }
 
+/*static*/ Packet Transport::find_announce_packet_from_hash(const Bytes& destination_hash) {
+	TRACEF("Transport::find_announce_packet_from_hash: Searching for announce packet for destination %s", destination_hash.toHex().c_str());
+	DestinationEntry destination_entry;
+	if (_new_path_table.get(destination_hash, destination_entry)) {
+		return destination_entry.announce_packet();
+	}
+
+	return {Type::NONE};
+}
+
 /*static*/ void Transport::cull_path_table() {
 	TRACE("Transport::cull_path_table()");
 	if (_path_table.size() > _path_table_maxsize) {

--- a/src/Transport.h
+++ b/src/Transport.h
@@ -345,6 +345,7 @@ namespace RNS {
 		static uint16_t remove_tunnels(const std::vector<Bytes>& hashes);
 
 		static Destination find_destination_from_hash(const Bytes& destination_hash);
+		static Packet find_announce_packet_from_hash(const Bytes& destination_hash);
 
 		// CBA
 		static void cull_path_table();


### PR DESCRIPTION
As discussed in #57 this PR fixes the of microReticulum if no identity is found in `_known_destinations` during `LRPROOF` handling. This happened because` Identity::recall` returned `{Type::NONE}` which leaves `Identity::_object` as `nullptr`. Therefore `peer_identity.get_public_key()` ran into `assert(_object)` and aborted. The fix was simply dropping the `LRPROOF` if there was no identity found.

This behavior is special to microReticulum and should not be observed in the Reticulum Reference Implementation because it does not have a limit to `_known_destinations`. In larger meshes it could be problematic that `_known_destinations` usually will have a smaller sizes than the path table due to restrained RAM, because link establishments would fail eventually in `LRPROOF` phase.
I came up with a fix for this: Since the path table stores the latest announce for each destination (which contains the needed public key etc.), the identity can be restored even if it is not cached in `_known_destinations`.