### PR TITLE
Initialize persistent stores regardless of enable_transport

### DIFF
--- a/src/microReticulum/Transport.cpp
+++ b/src/microReticulum/Transport.cpp
@@ -376,62 +376,66 @@ DestinationEntry empty_destination_entry;
 	//p thread = threading.Thread(target=Transport.jobloop, daemon=True)
 	//p thread.start()
 
-	// Load transport-related data
-	if (Reticulum::transport_enabled()) {
-		INFO("Transport mode is enabled");
-
-		// Read in path table
-		//read_path_table();
+	// Load persistent data stores. Every instance needs an identity cache, a
+	// path table and a packet hashlist to address anything at all, so these
+	// are not gated on transport mode. Gated, Identity::remember() fails on
+	// every inbound announce and no path is ever added.
+	// Read in path table
+	//read_path_table();
 #if defined(RNS_USE_FS) && RNS_PERSIST_PATHS
-		// CBA microStore
-		if (Utilities::OS::get_filesystem()) {
-			INFOF("FileSystem available: %lu bytes", Utilities::OS::get_filesystem().storageAvailable());
-			// CBA Must pass time offset into microStore for accurate timestamps on devices without a real-time clock
+	// CBA microStore
+	if (Utilities::OS::get_filesystem()) {
+		INFOF("FileSystem available: %lu bytes", Utilities::OS::get_filesystem().storageAvailable());
+		// CBA Must pass time offset into microStore for accurate timestamps on devices without a real-time clock
 #if defined(ARDUINO)
-			microStore::set_time_offset(Utilities::OS::getTimeOffset() / 1000);
+		microStore::set_time_offset(Utilities::OS::getTimeOffset() / 1000);
 #endif
-			TRACE("Initializing path table store...");
-			_path_store.init(Utilities::OS::get_filesystem(), "./path_store/", false, _path_store_segment_size, _path_store_segment_count);
-			// If the filesystem is full then clear the path store since it's of no use full anyway
-			if (Utilities::OS::get_filesystem().storageAvailable() > 0 && Utilities::OS::get_filesystem().storageAvailable() < 1024) {
-				WARNING("FileSystem is full, clearing existing path store");
-				_path_store.clear();
-			}
+		TRACE("Initializing path table store...");
+		_path_store.init(Utilities::OS::get_filesystem(), "./path_store/", false, _path_store_segment_size, _path_store_segment_count);
+		// If the filesystem is full then clear the path store since it's of no use full anyway
+		if (Utilities::OS::get_filesystem().storageAvailable() > 0 && Utilities::OS::get_filesystem().storageAvailable() < 1024) {
+			WARNING("FileSystem is full, clearing existing path store");
+			_path_store.clear();
 		}
+	}
 #endif // RNS_USE_FS && RNS_PERSIST_PATHS
 
 #if defined(RNS_USE_FS) && RNS_PERSIST_KNOWN_DESTINATIONS
-		if (Utilities::OS::get_filesystem()) {
-			// CBA Must pass time offset into microStore for accurate timestamps on devices without a real-time clock
+	if (Utilities::OS::get_filesystem()) {
+		// CBA Must pass time offset into microStore for accurate timestamps on devices without a real-time clock
 #if defined(ARDUINO)
-			microStore::set_time_offset(Utilities::OS::getTimeOffset() / 1000);
+		microStore::set_time_offset(Utilities::OS::getTimeOffset() / 1000);
 #endif
-			TRACE("Initializing known destinations store...");
-			Identity::_known_store.init(Utilities::OS::get_filesystem(), "./known_store/", false,
-				Identity::_known_store_segment_size, Identity::_known_store_segment_count);
-			if (Utilities::OS::get_filesystem().storageAvailable() > 0 && Utilities::OS::get_filesystem().storageAvailable() < 1024) {
-				WARNING("FileSystem is full, clearing existing known destinations store");
-				Identity::_known_store.clear();
-			}
+		TRACE("Initializing known destinations store...");
+		Identity::_known_store.init(Utilities::OS::get_filesystem(), "./known_store/", false,
+			Identity::_known_store_segment_size, Identity::_known_store_segment_count);
+		if (Utilities::OS::get_filesystem().storageAvailable() > 0 && Utilities::OS::get_filesystem().storageAvailable() < 1024) {
+			WARNING("FileSystem is full, clearing existing known destinations store");
+			Identity::_known_store.clear();
 		}
+	}
 #endif // RNS_USE_FS && RNS_PERSIST_KNOWN_DESTINATIONS
-		Identity::_known_store.set_max_recs(Identity::_known_destinations_maxsize);
+	Identity::_known_store.set_max_recs(Identity::_known_destinations_maxsize);
 
 #if defined(RNS_USE_FS) && RNS_PERSIST_HASHLIST
-		if (Utilities::OS::get_filesystem()) {
-			// CBA Must pass time offset into microStore for accurate timestamps on devices without a real-time clock
+	if (Utilities::OS::get_filesystem()) {
+		// CBA Must pass time offset into microStore for accurate timestamps on devices without a real-time clock
 #if defined(ARDUINO)
-			microStore::set_time_offset(Utilities::OS::getTimeOffset() / 1000);
+		microStore::set_time_offset(Utilities::OS::getTimeOffset() / 1000);
 #endif
-			TRACE("Initializing packet hashlist store...");
-			_packet_hash_store.init(Utilities::OS::get_filesystem(), "./hashlist_store/", false,
-				_hashlist_segment_size, _hashlist_segment_count);
-			if (Utilities::OS::get_filesystem().storageAvailable() > 0 && Utilities::OS::get_filesystem().storageAvailable() < 1024) {
-				WARNING("FileSystem is full, clearing existing packet hashlist store");
-				_packet_hash_store.clear();
-			}
+		TRACE("Initializing packet hashlist store...");
+		_packet_hash_store.init(Utilities::OS::get_filesystem(), "./hashlist_store/", false,
+			_hashlist_segment_size, _hashlist_segment_count);
+		if (Utilities::OS::get_filesystem().storageAvailable() > 0 && Utilities::OS::get_filesystem().storageAvailable() < 1024) {
+			WARNING("FileSystem is full, clearing existing packet hashlist store");
+			_packet_hash_store.clear();
 		}
+	}
 #endif // RNS_USE_FS && RNS_PERSIST_HASHLIST
+
+	// Load transport-related data
+	if (Reticulum::transport_enabled()) {
+		INFO("Transport mode is enabled");
 
 		// CBA The following write and clean is very resource intensive so skip at startup
 		// and let a later (optimized) scheduled write and clean take care of it.


### PR DESCRIPTION
**Fixes announce handling when transport is disabled**

`Transport::start()` only initialises the path table, known-destinations store, and packet hashlist inside `if (Reticulum::transport_enabled())`. So if you run an instance with transport disabled, those stores never get set up, and every inbound announce fails:

```
[ERR] remember: failed to store identity for <hash>
[ERR] Failed to add destination <hash> to path table!
```

No path ever gets added. The instance announces fine, logs nothing else, and just can't address a peer.

Easy to reproduce: with transport disabled, all four `test_interop` scenarios (packet, link, request, resource) fail the same way. (Worth noting the test_interop senders all set `transport_enabled(false)` themselves.) With the stores initialised, they pass bidirectionally against Python RNS 1.4.2 and 1.1.9. It's not version-specific either, 1.2.9 reproduces it too.

The fix: every instance needs an identity cache, a path table, and a packet hashlist to address anything, so those three initialisations move out of the gate. The tunnel table read and the probe destination stay inside it, since those really are transport-only.

Nothing changes for transport-enabled instances. The same three initialisations run in the same relative order, just before the `if` instead of inside it.

Tested on a native host build (`pio -e native17`, Ubuntu, Python RNS from pip). Haven't run it on hardware yet.

Opened at the request in #74. The diff looks bigger than it is, most of it is re-indentation from dropping a nesting level. With whitespace hidden (`?w=1`) it's about fourteen lines.