### PR TITLE
Apply the record cap to the path store in Transport::start()

### DIFF
--- a/src/microReticulum/Transport.cpp
+++ b/src/microReticulum/Transport.cpp
@@ -399,6 +399,15 @@ DestinationEntry empty_destination_entry;
 			}
 		}
 #endif // RNS_USE_FS && RNS_PERSIST_PATHS
+		// Apply the record cap to the path store, as is already done for the
+		// packet hashlist above and the known destinations below. Without this
+		// the RNS_PATH_TABLE_MAX default never reaches microStore, whose
+		// policy_max_recs defaults to 0 meaning disabled, so the path store
+		// runs uncapped unless the application calls
+		// Transport::path_table_maxsize() itself. The same value also gates
+		// compact_if_threshold(), so leaving it unset costs both the record cap
+		// and the compaction that reclaims expired records nothing reads back.
+		_path_store.set_max_recs(_path_table_maxsize);
 
 #if defined(RNS_USE_FS) && RNS_PERSIST_KNOWN_DESTINATIONS
 		if (Utilities::OS::get_filesystem()) {


### PR DESCRIPTION
**Fixes the path table size limit never being applied**

`Transport::start()` calls `set_max_recs()` for the packet-hashlist store and the known-destinations store, but not the path store. microStore's `policy_max_recs` defaults to `USTORE_DEFAULT_MAX_RECS` (`0`, disabled), so the `RNS_PATH_TABLE_MAX` default of 100 never reaches the store.

The same value is used by `compact_if_threshold()`. Leaving it unset disables both the record limit and threshold compaction. Lazy cleanup in `get()` and `exists()` does not cover this case, since expired records that are never accessed remain in storage.

The fix is to call `set_max_recs()` for the path store during `Transport::start()`, matching the other stores.

Nothing changes for users overriding the limit. The default remains 100.

### Against the Python reference

Checked against [`b48b96e`][ref].

* [`Transport.py:115`][L115] - `path_table = {}`, with no count limit.
* [`Transport.py:794`][L794] and [`Transport.py:901`][L901] - path entries are
  removed by expiry.
* [`Transport.py:177`][L177] and [`Transport.py:656`][L656] -
  `hashlist_maxsize = 1000000`, trimmed by count.

The Python implementation limits paths by age. microReticulum limits them by count. `RNS_PATH_TABLE_MAX` and `Transport::path_table_maxsize()` already existed, and `microReticulum_Firmware` already sets the value at boot with `URTN_PATH_TABLE_MAX_RECS`. This fixes the missing connection between that value and the store.

### Testing

**Tested on**

* Native host build - real `BasicFileStore` over a host filesystem.
  300 inserts leave 300 records without the limit, and 100 records with the limit set to 100.

**Not tested**

* compiles for nRF52840 but has not been run there

[ref]:  https://github.com/markqvist/Reticulum/tree/b48b96e61676504e0a4e527b33b9a0b4495c6872
[L115]: https://github.com/markqvist/Reticulum/blob/b48b96e61676504e0a4e527b33b9a0b4495c6872/RNS/Transport.py#L115
[L794]: https://github.com/markqvist/Reticulum/blob/b48b96e61676504e0a4e527b33b9a0b4495c6872/RNS/Transport.py#L794
[L901]: https://github.com/markqvist/Reticulum/blob/b48b96e61676504e0a4e527b33b9a0b4495c6872/RNS/Transport.py#L901
[L177]: https://github.com/markqvist/Reticulum/blob/b48b96e61676504e0a4e527b33b9a0b4495c6872/RNS/Transport.py#L177
[L656]: https://github.com/markqvist/Reticulum/blob/b48b96e61676504e0a4e527b33b9a0b4495c6872/RNS/Transport.py#L656