### PR TITLE
Implement Python-compatible interface access codes

### DIFF
--- a/src/microReticulum/Interface.cpp
+++ b/src/microReticulum/Interface.cpp
@@ -17,11 +17,69 @@
 #include "Identity.h"
 #include "Transport.h"
 #include "Type.h"
+#include "Cryptography/HKDF.h"
 
 using namespace RNS;
 using namespace RNS::Type::Interface;
 
 /*static*/ uint8_t Interface::DISCOVER_PATHS_FOR = MODE_ACCESS_POINT | MODE_GATEWAY | MODE_ROAMING;
+
+static const char* IFAC_SALT_HEX =
+	"adf54d882c9a9b80771eb4995d702d4a3e733391b2a0f53f416d9f907e55cff8";
+
+bool Interface::enable_ifac(const char* network_name, const char* passphrase,
+							uint8_t ifac_size) {
+	assert(_impl);
+	if (ifac_size < Type::Reticulum::IFAC_MIN_SIZE || ifac_size > 64) {
+		ERRORF("Invalid IFAC size %u; expected 1 to 64 bytes", ifac_size);
+		return false;
+	}
+
+	Bytes origin;
+	if (network_name != nullptr && network_name[0] != '\0') {
+		origin += Identity::full_hash(Bytes(network_name));
+	}
+	if (passphrase != nullptr && passphrase[0] != '\0') {
+		origin += Identity::full_hash(Bytes(passphrase));
+	}
+	if (!origin) {
+		ERROR("IFAC requires a network name, a passphrase, or both");
+		return false;
+	}
+
+	Bytes salt;
+	salt.assignHex(IFAC_SALT_HEX);
+	Bytes origin_hash = Identity::full_hash(origin);
+	Bytes key = Cryptography::hkdf(64, origin_hash, salt);
+	Identity identity(false);
+	if (!identity.load_private_key(key)) {
+		ERROR("Could not initialise IFAC identity");
+		return false;
+	}
+
+	// Commit only after every derivation step succeeds, so a bad update does
+	// not accidentally turn off a working access-controlled interface.
+	_impl->_ifac_key = key;
+	_impl->_ifac_identity = identity;
+	_impl->_ifac_size = ifac_size;
+	_impl->_ifac_netname = network_name != nullptr ? network_name : "";
+	_impl->_ifac_required = true;
+	return true;
+}
+
+void Interface::disable_ifac() {
+	assert(_impl);
+	_impl->_ifac_identity = Identity(Type::NONE);
+	_impl->_ifac_key = Bytes(Type::NONE);
+	_impl->_ifac_size = 0;
+	_impl->_ifac_netname.clear();
+	_impl->_ifac_required = false;
+}
+
+void Interface::require_ifac(bool required) {
+	assert(_impl);
+	_impl->_ifac_required = required;
+}
 
 void InterfaceImpl::handle_outgoing(const Bytes& data) {
 	//TRACEF("InterfaceImpl.handle_outgoing: data: %s", data.toHex().c_str());

--- a/src/microReticulum/Interface.cpp
+++ b/src/microReticulum/Interface.cpp
@@ -16,6 +16,7 @@
 
 #include "Identity.h"
 #include "Transport.h"
+#include "Type.h"
 
 using namespace RNS;
 using namespace RNS::Type::Interface;
@@ -51,11 +52,13 @@ bool Interface::send_outgoing(const Bytes& data) {
     }
     catch (const std::bad_alloc&) {
 		ERROR("Interface::send_outgoing: bad_alloc - OUT OF MEMORY");
-		// Critical OOM, restarting
-#if defined(ESP32)
+		// Shed this packet and keep running; see RNS_RESTART_ON_ALLOC_FAILURE.
+#if RNS_RESTART_ON_ALLOC_FAILURE
+  #if defined(ESP32)
 		ESP.restart();
-#elif defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_NRF52_ADAFRUIT)
+  #elif defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_NRF52_ADAFRUIT)
 		NVIC_SystemReset();
+  #endif
 #endif
     }
     catch (const std::exception& e) {
@@ -74,11 +77,13 @@ void Interface::handle_incoming(const Bytes& data) {
     }
     catch (const std::bad_alloc&) {
 		ERROR("Interface::handle_incoming: bad_alloc - OUT OF MEMORY");
-		// Critical OOM, restarting
-#if defined(ESP32)
+		// Shed this packet and keep running; see RNS_RESTART_ON_ALLOC_FAILURE.
+#if RNS_RESTART_ON_ALLOC_FAILURE
+  #if defined(ESP32)
 		ESP.restart();
-#elif defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_NRF52_ADAFRUIT)
+  #elif defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_NRF52_ADAFRUIT)
 		NVIC_SystemReset();
+  #endif
 #endif
     }
     catch (const std::exception& e) {

--- a/src/microReticulum/Interface.h
+++ b/src/microReticulum/Interface.h
@@ -94,7 +94,11 @@ namespace RNS {
 		bool _RPT = false;
 		std::string _name;
 		bool _online = false;
-		Bytes _ifac_identity;
+		Identity _ifac_identity = {Type::NONE};
+		Bytes _ifac_key;
+		uint8_t _ifac_size = 0;
+		std::string _ifac_netname;
+		bool _ifac_required = false;
 		Type::Interface::modes _mode = Type::Interface::MODE_NONE;
 		uint32_t _bitrate = 0;
 		uint16_t _HW_MTU = 0;
@@ -219,6 +223,15 @@ namespace RNS {
 	public:
 		// Public method to handle data coming in on interface and pass on to impl
 		void handle_incoming(const Bytes& data);
+		// Configure Reticulum Interface Access Codes from the same network-name
+		// and passphrase inputs accepted by Python RNS. At least one input must
+		// be non-empty. The default is the 64-bit IFAC used by radio interfaces.
+		bool enable_ifac(const char* network_name, const char* passphrase,
+		                 uint8_t ifac_size = 8);
+		void disable_ifac();
+		// Fail closed when configuration says access control is mandatory but
+		// key derivation could not be completed (for example, corrupt storage).
+		void require_ifac(bool required);
 
 	protected:
 		// setters
@@ -237,7 +250,12 @@ namespace RNS {
 		inline bool RPT() const { assert(_impl); return _impl->_RPT; }
 		inline bool online() const { assert(_impl); return _impl->_online; }
 		inline std::string name() const { assert(_impl); return _impl->_name; }
-		inline const Bytes& ifac_identity() const { assert(_impl); return _impl->_ifac_identity; }
+		inline bool ifac_enabled() const { assert(_impl); return static_cast<bool>(_impl->_ifac_identity); }
+		inline bool ifac_required() const { assert(_impl); return _impl->_ifac_required; }
+		inline const Identity& ifac_identity() const { assert(_impl); return _impl->_ifac_identity; }
+		inline const Bytes& ifac_key() const { assert(_impl); return _impl->_ifac_key; }
+		inline uint8_t ifac_size() const { assert(_impl); return _impl->_ifac_size; }
+		inline const std::string& ifac_netname() const { assert(_impl); return _impl->_ifac_netname; }
 		inline Type::Interface::modes mode() const { assert(_impl); return _impl->_mode; }
 		inline void mode(Type::Interface::modes mode) { assert(_impl); _impl->_mode = mode; }
 		inline uint32_t bitrate() const { assert(_impl); return _impl->_bitrate; }

--- a/src/microReticulum/Provisioning/Provisioning.cpp
+++ b/src/microReticulum/Provisioning/Provisioning.cpp
@@ -703,7 +703,9 @@ namespace RNS { namespace Provisioning {
 
 	// Packs a sparse Drafts sub-map { ns_id: { fid: draft_value, ... }, ... }
 	// for the given namespaces (call with only namespaces that actually have
-	// drafts). Shared by op_get_state and op_set_state so both emit
+	// drafts). Secret and write-only drafts are deliberately omitted for the
+	// same reason they are omitted from Values: neither may be echoed over a
+	// read path. Shared by op_get_state and op_set_state so both emit
 	// byte-identical Drafts content — lets the client cache-prime a GetState
 	// response with a hash returned by SetState.
 	static void pack_ns_drafts(MsgPack::Packer& p, const std::vector<const Namespace*>& draft_ns_list) {
@@ -712,10 +714,12 @@ namespace RNS { namespace Provisioning {
 			p.serialize((nid_t)ns->id());
 			size_t draft_entries = 0;
 			for (const Field& f : ns->fields()) {
+				if (f.has_flag(FF_SECRET) || f.has_flag(FF_WRITE_ONLY)) continue;
 				if (ns->has_draft(f.id)) ++draft_entries;
 			}
 			p.serialize(MsgPack::map_size_t(draft_entries));
 			for (const Field& f : ns->fields()) {
+				if (f.has_flag(FF_SECRET) || f.has_flag(FF_WRITE_ONLY)) continue;
 				Value v;
 				if (!ns->draft(f.id, v)) continue;
 				p.serialize((fid_t)f.id);

--- a/src/microReticulum/Reticulum.cpp
+++ b/src/microReticulum/Reticulum.cpp
@@ -253,11 +253,13 @@ void Reticulum::loop() {
     }
     catch (const std::bad_alloc&) {
 		ERROR("Reticulum::loop: bad_alloc - OUT OF MEMORY");
-		// Critical OOM, restarting
-#if defined(ESP32)
+		// Skip this iteration rather than restart; see RNS_RESTART_ON_ALLOC_FAILURE.
+#if RNS_RESTART_ON_ALLOC_FAILURE
+  #if defined(ESP32)
 		ESP.restart();
-#elif defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_NRF52_ADAFRUIT)
+  #elif defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_NRF52_ADAFRUIT)
 		NVIC_SystemReset();
+  #endif
 #endif
     }
     catch (const std::exception& e) {

--- a/src/microReticulum/Transport.cpp
+++ b/src/microReticulum/Transport.cpp
@@ -21,6 +21,7 @@
 #include "Packet.h"
 #include "Interface.h"
 #include "Log.h"
+#include "Cryptography/HKDF.h"
 #include "Cryptography/Random.h"
 #include "Utilities/OS.h"
 #include "Utilities/Persistence.h"
@@ -1102,45 +1103,31 @@ TRACEF("path_request_conditions=%u", path_request_conditions);
 		}
 	}
 	try {
-		//if hasattr(interface, "ifac_identity") and interface.ifac_identity != None:
-		if (interface.ifac_identity()) {
-// TODO
-/*p
+		if (interface.ifac_required() && !interface.ifac_enabled()) {
+			ERRORF("Refusing unprotected transmission on IFAC-required interface %s",
+				interface.toString().c_str());
+			return false;
+		}
+		if (interface.ifac_enabled()) {
 			// Calculate packet access code
-			ifac = interface.ifac_identity.sign(raw)[-interface.ifac_size:]
+			Bytes ifac = interface.ifac_identity().sign(raw).right(interface.ifac_size());
 
 			// Generate mask
-			mask = RNS.Cryptography.hkdf(
-				length=len(raw)+interface.ifac_size,
-				derive_from=ifac,
-				salt=interface.ifac_key,
-				context=None,
-			)
+			Bytes mask = Cryptography::hkdf(raw.size() + interface.ifac_size(),
+													ifac, interface.ifac_key());
 
-			// Set IFAC flag
-			new_header = bytes([raw[0] | 0x80, raw[1]])
-
-			// Assemble new payload with IFAC
-			new_raw    = new_header+ifac+raw[2:]
-			
-			// Mask payload
-			i = 0; masked_raw = b""
-			for byte in new_raw:
-				if i == 0:
-					// Mask first header byte, but make sure the
-					// IFAC flag is still set
-					masked_raw += bytes([byte ^ mask[i] | 0x80])
-				elif i == 1 or i > interface.ifac_size+1:
-					// Mask second header byte and payload
-					masked_raw += bytes([byte ^ mask[i]])
-				else:
-					// Don't mask the IFAC itself
-					masked_raw += bytes([byte])
-				i += 1
-
-			// Send it
-			sent = interface.on_outgoing(masked_raw)
-*/
+			// Set the IFAC flag, insert the unmasked IFAC after the two-byte
+			// header, then mask both header bytes and the packet payload.
+			Bytes protected_raw(raw.size() + interface.ifac_size());
+			uint8_t* output = protected_raw.writable(raw.size() + interface.ifac_size());
+			output[0] = ((raw[0] | 0x80) ^ mask[0]) | 0x80;
+			output[1] = raw[1] ^ mask[1];
+			memcpy(output + 2, ifac.data(), ifac.size());
+			for (size_t i = 2; i < raw.size(); ++i) {
+				const size_t output_index = i + interface.ifac_size();
+				output[output_index] = raw[i] ^ mask[output_index];
+			}
+			sent = interface.send_outgoing(protected_raw);
 		}
 		else {
 			sent = interface.send_outgoing(raw);
@@ -1696,83 +1683,86 @@ TRACEF("path_request_conditions=%u", path_request_conditions);
 
 /*static*/ void Transport::inbound(const Bytes& raw, const Interface& interface /*= {Type::NONE}*/) {
 	TRACEF("Transport::inbound: received %d bytes", raw.size());
+	Bytes packet_raw = raw;
+	if (interface && interface.ifac_required() && !interface.ifac_enabled()) {
+		return;
+	}
+
+	// If interface access codes are enabled,
+	// we must authenticate each packet.
+	if (packet_raw.size() > 2) {
+		if (interface && interface.ifac_enabled()) {
+			// Check that IFAC flag is set
+			if ((packet_raw[0] & 0x80) == 0x80) {
+				if (packet_raw.size() > static_cast<size_t>(2 + interface.ifac_size())) {
+					// Extract IFAC
+					Bytes ifac = packet_raw.mid(2, interface.ifac_size());
+
+					// Generate mask
+					Bytes mask = Cryptography::hkdf(packet_raw.size(), ifac,
+													interface.ifac_key());
+
+					// Unmask payload
+					// Bytes copies share storage. Construct from the underlying buffer
+					// so writable() preserves the received frame while unmasking it.
+					Bytes unmasked_raw(packet_raw.data(), packet_raw.size());
+					uint8_t* unmasked = unmasked_raw.writable(unmasked_raw.size());
+					for (size_t i = 0; i < unmasked_raw.size(); ++i) {
+						if (i <= 1 || i > static_cast<size_t>(interface.ifac_size() + 1)) {
+							unmasked[i] ^= mask[i];
+						}
+					}
+
+					Bytes new_raw(unmasked_raw.size() - interface.ifac_size());
+					uint8_t* output = new_raw.writable(unmasked_raw.size() - interface.ifac_size());
+					output[0] = unmasked[0] & 0x7f;
+					output[1] = unmasked[1];
+					memcpy(output + 2, unmasked + 2 + interface.ifac_size(),
+							 unmasked_raw.size() - 2 - interface.ifac_size());
+
+					// Calculate expected IFAC
+					Bytes expected_ifac = interface.ifac_identity().sign(new_raw)
+													.right(interface.ifac_size());
+
+					// Check it
+					uint8_t difference = 0;
+					for (size_t i = 0; i < ifac.size(); ++i) {
+						difference |= ifac[i] ^ expected_ifac[i];
+					}
+					if (difference != 0) return;
+					packet_raw = new_raw;
+				}
+				else return;
+
+			}
+			else {
+				// If the IFAC flag is not set, but should be,
+				// drop the packet.
+				return;
+			}
+
+		}
+		else {
+			// If the interface does not have IFAC enabled,
+			// check the received packet IFAC flag.
+			// If the flag is set, drop the packet.
+			if ((packet_raw[0] & 0x80) == 0x80) return;
+		}
+	}
+	else {
+		return;
+	}
+
 	++_packets_received;
-	// CBA
+	// Callbacks must only observe authenticated, unmasked packet bytes.
 	if (_callbacks._receive_packet) {
 		try {
-			_callbacks._receive_packet(raw, interface);
+			_callbacks._receive_packet(packet_raw, interface);
 		}
 		catch (const std::exception& e) {
 			DEBUGF("Error while executing receive packet callback. The contained exception was: %s", e.what());
 		}
 	}
-// TODO
-/*p
-	// If interface access codes are enabled,
-	// we must authenticate each packet.
-	//if len(raw) > 2:
-	if (raw.size() > 2) {
-		if interface != None and hasattr(interface, "ifac_identity") and interface.ifac_identity != None:
-			// Check that IFAC flag is set
-			if raw[0] & 0x80 == 0x80:
-				if len(raw) > 2+interface.ifac_size:
-					// Extract IFAC
-					ifac = raw[2:2+interface.ifac_size]
-
-					// Generate mask
-					mask = RNS.Cryptography.hkdf(
-						length=len(raw),
-						derive_from=ifac,
-						salt=interface.ifac_key,
-						context=None,
-					)
-
-					// Unmask payload
-					i = 0; unmasked_raw = b""
-					for byte in raw:
-						if i <= 1 or i > interface.ifac_size+1:
-							// Unmask header bytes and payload
-							unmasked_raw += bytes([byte ^ mask[i]])
-						else:
-							// Don't unmask IFAC itself
-							unmasked_raw += bytes([byte])
-						i += 1
-					raw = unmasked_raw
-
-					// Unset IFAC flag
-					new_header = bytes([raw[0] & 0x7f, raw[1]])
-
-					// Re-assemble packet
-					new_raw = new_header+raw[2+interface.ifac_size:]
-
-					// Calculate expected IFAC
-					expected_ifac = interface.ifac_identity.sign(new_raw)[-interface.ifac_size:]
-
-					// Check it
-					if ifac == expected_ifac:
-						raw = new_raw
-					else:
-						return
-
-				else:
-					return
-
-			else:
-				// If the IFAC flag is not set, but should be,
-				// drop the packet.
-				return
-
-		else:
-			// If the interface does not have IFAC enabled,
-			// check the received packet IFAC flag.
-			if raw[0] & 0x80 == 0x80:
-				// If the flag is set, drop the packet
-				return
-	}
-	else {
-		return;
-	}
-*/
 
 	if (_jobs_running) DEBUG("Transport::inbound: jobs still running!");
 	while (_jobs_running) {
@@ -1787,7 +1777,7 @@ TRACEF("path_request_conditions=%u", path_request_conditions);
 
 	_jobs_locked = true;
 
-	Packet packet(Destination(Type::NONE), raw);
+	Packet packet(Destination(Type::NONE), packet_raw);
 	if (!packet.unpack()) {
 		WARNING("Transport::inbound: Packet unpack failed!");
 		return;

--- a/src/microReticulum/Type.h
+++ b/src/microReticulum/Type.h
@@ -53,6 +53,22 @@
 
 #ifndef RNS_QUEUED_ANNOUNCES_MAX
 #define RNS_QUEUED_ANNOUNCES_MAX 20
+
+// Whether a failed allocation should restart the device.
+//
+// A std::bad_alloc while handling one packet is usually transient -- a burst of
+// traffic against a fragmented heap. Restarting takes the node off the mesh and
+// discards its path table, link table and announce state to recover from a
+// single packet, and on a transport node that is far more damaging than dropping
+// the packet: RNS retries above this layer, but nothing restores a router that
+// disappeared. Default to shedding the packet and continuing.
+//
+// This does not affect the RNS_LOW_MEMORY_REBOOT guard in Reticulum::loop(),
+// which is a deliberate last resort: it fires only on sustained exhaustion
+// (<=2% heap), logs at CRITICAL, and persists state before restarting.
+#ifndef RNS_RESTART_ON_ALLOC_FAILURE
+#define RNS_RESTART_ON_ALLOC_FAILURE 0
+#endif
 #endif
 
 #ifndef RNS_RECEIPTS_MAX

--- a/src/microReticulum/Utilities/Memory.h
+++ b/src/microReticulum/Utilities/Memory.h
@@ -19,6 +19,7 @@
 #include "tlsf/tlsf.h"
 
 #include <memory>
+#include <stdint.h>
 
 #define RNS_HEAP_ALLOCATOR 0		 // Use HEAP for allocator
 #define RNS_HEAP_POOL_ALLOCATOR 1	 // Use HEAP pool for allocator

--- a/test/test_ifac/test_ifac.cpp
+++ b/test/test_ifac/test_ifac.cpp
@@ -1,0 +1,188 @@
+#include <unity.h>
+
+#include "microReticulum.h"
+
+static RNS::Bytes captured_outgoing;
+static RNS::Bytes captured_incoming;
+static unsigned int incoming_callbacks = 0;
+
+class CaptureInterface : public RNS::InterfaceImpl {
+public:
+	CaptureInterface() : RNS::InterfaceImpl("IFACVectorInterface") {
+		_IN = true;
+		_OUT = true;
+	}
+
+protected:
+	bool send_outgoing(const RNS::Bytes& data) override {
+		captured_outgoing = data;
+		return true;
+	}
+};
+
+static void capture_incoming(const RNS::Bytes& raw,
+								 const RNS::Interface&) {
+	captured_incoming = raw;
+	++incoming_callbacks;
+}
+
+static RNS::Interface vector_interface() {
+	RNS::Interface interface(new CaptureInterface());
+	TEST_ASSERT_TRUE(interface.enable_ifac("IFAC interoperability test",
+														 "not-a-secret", 8));
+	return interface;
+}
+
+static RNS::Interface vector_interface_16() {
+	RNS::Interface interface(new CaptureInterface());
+	TEST_ASSERT_TRUE(interface.enable_ifac("IFAC interoperability test",
+												 "not-a-secret", 16));
+	return interface;
+}
+
+static RNS::Bytes vector_raw() {
+	RNS::Bytes raw;
+	raw.assignHex("0100112233445566778899aabbccddeeff2a48656c6c6f2049464143");
+	return raw;
+}
+
+void test_ifac_key_derivation_matches_python_rns() {
+	RNS::Interface interface = vector_interface();
+	TEST_ASSERT_EQUAL_STRING(
+		"9213858a8ddc452925f22e758377f97dd7fe28103d3c5093c14c1c4951291667"
+		"f78f058332cdb942924002513f0e2abaa68b2fdcd2a460c5a025402c70888992",
+		interface.ifac_key().toHex().c_str());
+	TEST_ASSERT_EQUAL_UINT8(8, interface.ifac_size());
+	TEST_ASSERT_EQUAL_STRING("IFAC interoperability test",
+		interface.ifac_netname().c_str());
+}
+
+void test_ifac_outbound_frame_matches_python_rns() {
+	RNS::Interface interface = vector_interface();
+	captured_outgoing = RNS::Bytes(RNS::Type::NONE);
+
+	TEST_ASSERT_TRUE(RNS::Transport::transmit(interface, vector_raw()));
+	TEST_ASSERT_EQUAL_STRING(
+		"c48f73ed6d83828b5f017e7f2632dd0f857cbf7e7ccb21791ef6078024a36861"
+		"4af42e6b",
+		captured_outgoing.toHex().c_str());
+}
+
+void test_ifac_inbound_frame_matches_python_rns() {
+	RNS::Interface interface = vector_interface();
+	RNS::Bytes wire;
+	wire.assignHex(
+		"c48f73ed6d83828b5f017e7f2632dd0f857cbf7e7ccb21791ef6078024a36861"
+		"4af42e6b");
+	captured_incoming = RNS::Bytes(RNS::Type::NONE);
+	incoming_callbacks = 0;
+	RNS::Transport::set_receive_packet_callback(capture_incoming);
+
+	RNS::Transport::inbound(wire, interface);
+
+	TEST_ASSERT_EQUAL_UINT(1, incoming_callbacks);
+	TEST_ASSERT_EQUAL_STRING(vector_raw().toHex().c_str(),
+		captured_incoming.toHex().c_str());
+}
+
+void test_ifac_16_byte_frame_matches_python_rns() {
+	RNS::Interface interface = vector_interface_16();
+	captured_outgoing = RNS::Bytes(RNS::Type::NONE);
+
+	TEST_ASSERT_TRUE(RNS::Transport::transmit(interface, vector_raw()));
+	TEST_ASSERT_EQUAL_STRING(
+		"c31971a3134e74f6fadd73ed6d83828b5f014d5391038ecec91d8739d879c340"
+		"1e878271525080b1c72fd69c",
+		captured_outgoing.toHex().c_str());
+
+	captured_incoming = RNS::Bytes(RNS::Type::NONE);
+	incoming_callbacks = 0;
+	RNS::Transport::set_receive_packet_callback(capture_incoming);
+	RNS::Transport::inbound(captured_outgoing, interface);
+
+	TEST_ASSERT_EQUAL_UINT(1, incoming_callbacks);
+	TEST_ASSERT_EQUAL_STRING(vector_raw().toHex().c_str(),
+		captured_incoming.toHex().c_str());
+}
+
+void test_ifac_rejects_tampering_and_wrong_network() {
+	RNS::Interface interface = vector_interface();
+	RNS::Bytes wire;
+	wire.assignHex(
+		"c48f73ed6d83828b5f017e7f2632dd0f857cbf7e7ccb21791ef6078024a36861"
+		"4af42e6b");
+	wire.writable(wire.size())[wire.size() - 1] ^= 0x01;
+	incoming_callbacks = 0;
+	uint32_t packets_before = RNS::Transport::packets_received();
+	RNS::Transport::set_receive_packet_callback(capture_incoming);
+	RNS::Transport::inbound(wire, interface);
+	TEST_ASSERT_EQUAL_UINT(0, incoming_callbacks);
+	TEST_ASSERT_EQUAL_UINT32(packets_before, RNS::Transport::packets_received());
+
+	RNS::Interface wrong(new CaptureInterface());
+	TEST_ASSERT_TRUE(wrong.enable_ifac("different network", "not-a-secret", 8));
+	RNS::Transport::inbound(captured_outgoing, wrong);
+	TEST_ASSERT_EQUAL_UINT(0, incoming_callbacks);
+	TEST_ASSERT_EQUAL_UINT32(packets_before, RNS::Transport::packets_received());
+}
+
+void test_ifac_enforces_closed_and_open_interfaces() {
+	RNS::Interface closed = vector_interface();
+	RNS::Interface open(new CaptureInterface());
+	RNS::Bytes protected_frame;
+	protected_frame.assignHex(
+		"c48f73ed6d83828b5f017e7f2632dd0f857cbf7e7ccb21791ef6078024a36861"
+		"4af42e6b");
+	incoming_callbacks = 0;
+	RNS::Transport::set_receive_packet_callback(capture_incoming);
+
+	RNS::Transport::inbound(vector_raw(), closed);
+	RNS::Transport::inbound(protected_frame, open);
+	TEST_ASSERT_EQUAL_UINT(0, incoming_callbacks);
+}
+
+void test_ifac_configuration_validation_is_transactional() {
+	RNS::Interface interface = vector_interface();
+	RNS::Bytes original_key = interface.ifac_key();
+	TEST_ASSERT_FALSE(interface.enable_ifac("", "", 8));
+	TEST_ASSERT_FALSE(interface.enable_ifac("network", "secret", 0));
+	TEST_ASSERT_FALSE(interface.enable_ifac("network", "secret", 65));
+	TEST_ASSERT_TRUE(interface.ifac_enabled());
+	TEST_ASSERT_TRUE(original_key == interface.ifac_key());
+
+	interface.disable_ifac();
+	TEST_ASSERT_FALSE(interface.ifac_enabled());
+	TEST_ASSERT_EQUAL_UINT8(0, interface.ifac_size());
+	TEST_ASSERT_TRUE(interface.ifac_key().empty());
+}
+
+void test_ifac_required_without_a_key_fails_closed() {
+	RNS::Interface interface(new CaptureInterface());
+	interface.require_ifac(true);
+	captured_outgoing = RNS::Bytes(RNS::Type::NONE);
+	incoming_callbacks = 0;
+	RNS::Transport::set_receive_packet_callback(capture_incoming);
+
+	TEST_ASSERT_FALSE(RNS::Transport::transmit(interface, vector_raw()));
+	RNS::Transport::inbound(vector_raw(), interface);
+	TEST_ASSERT_FALSE(captured_outgoing);
+	TEST_ASSERT_EQUAL_UINT(0, incoming_callbacks);
+}
+
+void setUp(void) {}
+void tearDown(void) {
+	RNS::Transport::set_receive_packet_callback(nullptr);
+}
+
+int main(void) {
+	UNITY_BEGIN();
+	RUN_TEST(test_ifac_key_derivation_matches_python_rns);
+	RUN_TEST(test_ifac_outbound_frame_matches_python_rns);
+	RUN_TEST(test_ifac_inbound_frame_matches_python_rns);
+	RUN_TEST(test_ifac_16_byte_frame_matches_python_rns);
+	RUN_TEST(test_ifac_rejects_tampering_and_wrong_network);
+	RUN_TEST(test_ifac_enforces_closed_and_open_interfaces);
+	RUN_TEST(test_ifac_configuration_validation_is_transactional);
+	RUN_TEST(test_ifac_required_without_a_key_fails_closed);
+	return UNITY_END();
+}

--- a/test/test_provisioning/test_provisioning.cpp
+++ b/test/test_provisioning/test_provisioning.cpp
@@ -686,6 +686,61 @@ void test_transport_identity_excluded_from_get_state(void) {
 	TEST_ASSERT_FALSE(found_secret);
 }
 
+void test_transport_identity_draft_excluded_from_get_state(void) {
+	// SECRET must cover pending drafts as well as committed working values.
+	// Otherwise any GetState(Draft=true) caller could retrieve a passphrase
+	// while it was staged for commit.
+	fresh_provisioning(g_test_root);
+	auto& p = Provisioner::instance();
+	RNS::Identity src;
+	TEST_ASSERT_TRUE(p.field(Ns::GeneralConfig::Id,
+		Ns::GeneralConfig::Field::TransportIdentity,
+		Value(src.get_private_key())));
+
+	Bytes req = make_request((uint8_t)Op::GetState, 1, [&](MsgPack::Packer& pk) {
+		pk.serialize(MsgPack::map_size_t(2));
+		pk.serialize((uint16_t)Key::NamespaceFilter);
+		pk.serialize(MsgPack::arr_size_t(1));
+		pk.serialize((uint16_t)Ns::GeneralConfig::Id);
+		pk.serialize((uint16_t)Key::Draft);
+		pk.serialize((bool)true);
+	});
+	Bytes resp = p.handle_message(req);
+
+	MsgPack::Unpacker u; u.feed(resp.data(), resp.size());
+	u.unpackArraySize();
+	uint8_t op = 0; u.deserialize(op);
+	uint64_t seq = 0; u.deserialize(seq);
+	TEST_ASSERT_EQUAL((uint8_t)Op::GetState, op);
+	TEST_ASSERT_TRUE(u.isMap());
+	const size_t body_entries = u.unpackMapSize();
+
+	bool saw_drafts = false;
+	bool found_secret = false;
+	for (size_t i = 0; i < body_entries; ++i) {
+		int64_t key = 0; u.deserialize(key);
+		if (key != Key::Drafts) {
+			t_skip_value(u);
+			continue;
+		}
+		saw_drafts = true;
+		TEST_ASSERT_TRUE(u.isMap());
+		const size_t nns = u.unpackMapSize();
+		TEST_ASSERT_EQUAL_size_t(1, nns);
+		int64_t nsid = 0; u.deserialize(nsid);
+		TEST_ASSERT_EQUAL((int64_t)Ns::GeneralConfig::Id, nsid);
+		TEST_ASSERT_TRUE(u.isMap());
+		const size_t nf = u.unpackMapSize();
+		for (size_t j = 0; j < nf; ++j) {
+			int64_t fid = 0; u.deserialize(fid);
+			if (fid == Ns::GeneralConfig::Field::TransportIdentity) found_secret = true;
+			t_skip_value(u);
+		}
+	}
+	TEST_ASSERT_TRUE(saw_drafts);
+	TEST_ASSERT_FALSE(found_secret);
+}
+
 // ---------------------------------------------------------------------------
 // Metric (read-only + getter) and command (write-only + setter) patterns
 // ---------------------------------------------------------------------------
@@ -2261,6 +2316,7 @@ int runUnityTests(void) {
 	RUN_TEST(test_transport_identity_getter_unset_returns_empty);
 	RUN_TEST(test_transport_identity_commit_reloads_on_reboot);
 	RUN_TEST(test_transport_identity_excluded_from_get_state);
+	RUN_TEST(test_transport_identity_draft_excluded_from_get_state);
 	RUN_TEST(test_metric_getter_reflects_runtime);
 	RUN_TEST(test_metric_rejects_set_state);
 	RUN_TEST(test_metric_not_persisted);


### PR DESCRIPTION
Implements Python-compatible interface access codes (IFAC) for interoperability with Reticulum.

- Add IFAC handling to interfaces and transport processing.
- Cover IFAC behavior with dedicated tests.
- Keep secret provisioning drafts off the wire.

This enables interoperable IFAC-protected traffic while preventing sensitive provisioning material from being transmitted.