### PR TITLE
Make the housekeeping job interval configurable

### DIFF
--- a/src/microReticulum/Reticulum.cpp
+++ b/src/microReticulum/Reticulum.cpp
@@ -43,6 +43,7 @@ using namespace RNS::Utilities;
 /*static*/ const Reticulum& Reticulum::_instance = {Type::NONE};
 
 /*static*/ bool Reticulum::__transport_enabled = false;
+/*static*/ float Reticulum::__jobs_interval = (float)Type::Reticulum::JOB_INTERVAL;
 /*static*/ bool Reticulum::__link_mtu_discovery = RNS::Type::Reticulum::LINK_MTU_DISCOVERY;
 /*static*/ bool Reticulum::__remote_management_enabled = false;
 /*static*/ bool Reticulum::__use_implicit_proof = true;
@@ -229,7 +230,7 @@ void Reticulum::loop() {
 		if (!_object->_is_connected_to_shared_instance) {
 
 			// Perform Reticulum housekeeping
-			if (OS::time() > (_object->_jobs_last_run + JOB_INTERVAL)) {
+			if (OS::time() > (_object->_jobs_last_run + __jobs_interval)) {
 				jobs();
 			}
 

--- a/src/microReticulum/Reticulum.h
+++ b/src/microReticulum/Reticulum.h
@@ -53,6 +53,7 @@ namespace RNS {
 		static const Reticulum& _instance;
 
 		static bool __transport_enabled;
+		static float __jobs_interval;
         static bool __link_mtu_discovery;
         static bool __remote_management_enabled;
 		static bool __use_implicit_proof;
@@ -140,6 +141,12 @@ namespace RNS {
 
 		:returns: True if Transport is enabled, False if not.
 		*/
+		// Interval between housekeeping passes in loop() (announce
+		// rebroadcasts, link and receipt timeouts, table culling). Reference
+		// RNS runs its equivalent every 0.25 s; a long interval delays
+		// announce propagation between interfaces by up to that long.
+		inline static float jobs_interval() { return __jobs_interval; }
+		inline static void jobs_interval(float seconds) { __jobs_interval = seconds; }
 		inline static bool transport_enabled() { return __transport_enabled; }
 		inline static void transport_enabled(bool transport_enabled) { __transport_enabled = transport_enabled; }
 

--- a/src/microReticulum/Type.h
+++ b/src/microReticulum/Type.h
@@ -201,6 +201,7 @@ namespace RNS { namespace Type {
 		static const uint32_t RESOURCE_CACHE   = 60*60*24;
 		// CBA TEST
 		//static const uint16_t JOB_INTERVAL     = 60*5;
+		// Default housekeeping interval; adjustable at runtime via Reticulum::jobs_interval().
 		static const uint16_t JOB_INTERVAL     = 60;
 		// CBA TEST
 		static const uint16_t CLEAN_INTERVAL   = 60*15;


### PR DESCRIPTION
Reticulum::loop() runs Transport::jobs() every Type::Reticulum::JOB_INTERVAL (60 s), and announce rebroadcasts, link/receipt timeouts and path-request handling all live there. Applications that bridge interfaces on the same device therefore saw announces forwarded up to a minute late, with no way to change it short of calling Transport::jobs() themselves.

Add Reticulum::jobs_interval() getter/setter (seconds); the default stays JOB_INTERVAL = 60 so existing behaviour is unchanged. Reference RNS runs its equivalent every 0.25 s; 1 s is a good value on an ESP32.

Tested 1s interval on ESP32-S3 bridging announcement packets between LoRa and WiFi without any issues.

Closes #83 